### PR TITLE
Mysql 5.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,12 +50,12 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>9.2-1004-jdbc4</version>
+			<version>9.4-1201-jdbc41</version>
 		</dependency>
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.33</version>
+			<version>5.1.35</version>
 		</dependency>
 
 		<!-- Testing -->

--- a/src/main/java/io/quantumdb/nemesis/Grapher.java
+++ b/src/main/java/io/quantumdb/nemesis/Grapher.java
@@ -17,7 +17,7 @@ public class Grapher {
 	private static final int SKIP_UNTIL = 45_000;
 	private static final int PADDING = 20;
 	private static final int WIDTH = 1000;
-	private static final int HEIGHT = 150;
+	private static final int HEIGHT = 60;
 	private static final int SCALE = 30;  // Pixels per second
 
 //	private static final int SKIP_UNTIL = 0;
@@ -29,10 +29,9 @@ public class Grapher {
 	private static final int RESOLUTION = (1000 / SCALE);
 	private static final int LIMIT = WIDTH * RESOLUTION + SKIP_UNTIL;
 
-	private static final File DIR = new File("/Users/michael/logs/MYSQL/");
-
 	public static void main(String[] args) throws IOException {
-		File[] scenarios = DIR.listFiles(file -> file.isDirectory() && !file.getName().startsWith(".") && !file.getName().startsWith("_"));
+		File dir = new File(args[0]);
+		File[] scenarios = dir.listFiles(file -> file.isDirectory() && !file.getName().startsWith(".") && !file.getName().startsWith("_"));
 		for (File scenario : scenarios) {
 			new Grapher().graphResponseTimes(scenario);
 			log.info("Graphed: " + scenario.getAbsolutePath());
@@ -109,6 +108,7 @@ public class Grapher {
 		}
 
 		ImageIO.write(image, "png", new File(folder, folder.getName() + ".png"));
+		ImageIO.write(image, "png", new File(new File(folder.getParent(), "graphs"), folder.getName() + ".png"));
 	}
 
 	private int toX(long x) {

--- a/src/main/java/io/quantumdb/nemesis/Launcher.java
+++ b/src/main/java/io/quantumdb/nemesis/Launcher.java
@@ -8,6 +8,7 @@ import io.quantumdb.nemesis.profiler.DatabaseStructure;
 import io.quantumdb.nemesis.profiler.Profiler;
 import io.quantumdb.nemesis.profiler.ProfilerConfig;
 import io.quantumdb.nemesis.structure.Database;
+import io.quantumdb.nemesis.structure.Database.Type;
 import io.quantumdb.nemesis.structure.DatabaseCredentials;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -31,8 +32,9 @@ public class Launcher {
 		while (true) {
 			System.out.println("\nType of database?\n");
 			System.out.println("  1. PostgreSQL.");
-			System.out.println("  2. MySQL.");
-			System.out.println("  3. Exit.");
+			System.out.println("  2. MySQL 5.5.");
+			System.out.println("  3. MySQL 5.6.");
+			System.out.println("  4. Exit.");
 			System.out.println("");
 			System.out.print("Option: ");
 
@@ -42,12 +44,15 @@ public class Launcher {
 
 				switch (option) {
 					case 1:
-						setCredentials(reader, Database.Type.POSTGRESQL);
+						setCredentials(reader, Type.POSTGRESQL);
 						break;
 					case 2:
-						setCredentials(reader, Database.Type.MYSQL);
+						setCredentials(reader, Type.MYSQL_55);
 						break;
 					case 3:
+						setCredentials(reader, Type.MYSQL_56);
+						break;
+					case 4:
 						return;
 					default:
 						System.err.println("You must choose an option in range [1..3]");

--- a/src/main/java/io/quantumdb/nemesis/structure/Database.java
+++ b/src/main/java/io/quantumdb/nemesis/structure/Database.java
@@ -4,16 +4,21 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
 
-import io.quantumdb.nemesis.structure.mysql.MysqlDatabase;
 import io.quantumdb.nemesis.structure.postgresql.PostgresDatabase;
 
 public interface Database {
 
 	public enum Type {
-		MYSQL {
+		MYSQL_56 {
 			@Override
 			public Database createBackend() {
-				return new MysqlDatabase();
+				return new io.quantumdb.nemesis.structure.mysql56.MysqlDatabase();
+			}
+		},
+		MYSQL_55 {
+			@Override
+			public Database createBackend() {
+				return new io.quantumdb.nemesis.structure.mysql55.MysqlDatabase();
 			}
 		},
 		POSTGRESQL {

--- a/src/main/java/io/quantumdb/nemesis/structure/mysql55/MysqlColumn.java
+++ b/src/main/java/io/quantumdb/nemesis/structure/mysql55/MysqlColumn.java
@@ -1,0 +1,171 @@
+package io.quantumdb.nemesis.structure.mysql55;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+import io.quantumdb.nemesis.structure.Column;
+import io.quantumdb.nemesis.structure.ColumnDefinition;
+import io.quantumdb.nemesis.structure.QueryBuilder;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ToString
+@EqualsAndHashCode
+class MysqlColumn implements Column {
+
+	private final Connection connection;
+	private final MysqlTable parent;
+
+	private String name;
+	private String defaultExpression;
+	private boolean nullable;
+	private String type;
+	private boolean identity;
+	private boolean autoIncrement;
+
+	MysqlColumn(Connection connection, MysqlTable parent, ColumnDefinition column) {
+		this(connection, parent, column.getName(), column.getDefaultExpression(), column.isNullable(),
+				column.getType(), column.isIdentity(), column.isAutoIncrement());
+	}
+
+	MysqlColumn(Connection connection, MysqlTable parent, String name, String defaultExpression,
+			boolean nullable, String dataType, boolean identityColumn, boolean autoIncrement) {
+
+		this.connection = connection;
+		this.parent = parent;
+		this.name = name;
+		this.defaultExpression = defaultExpression;
+		this.nullable = nullable;
+		this.type = dataType;
+		this.identity = identityColumn;
+		this.autoIncrement = autoIncrement;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public void rename(String newName) throws SQLException {
+		execute(String.format("ALTER TABLE %s CHANGE COLUMN %s %s", parent.getName(), name,
+				getDefinition(newName, type, nullable, autoIncrement, defaultExpression)));
+		this.name = newName;
+	}
+
+	@Override
+	public MysqlTable getParent() {
+		return parent;
+	}
+
+	@Override
+	public String getType() {
+		return type;
+	}
+
+	@Override
+	public void setType(String newType) throws SQLException {
+		execute(String.format("ALTER TABLE %s MODIFY COLUMN %s", parent.getName(),
+				getDefinition(name, newType, nullable, autoIncrement, defaultExpression)));
+
+		this.type = newType;
+	}
+
+	@Override
+	public boolean isNullable() {
+		return nullable;
+	}
+
+	@Override
+	public void setNullable(boolean isNullable) throws SQLException {
+		execute(String.format("ALTER TABLE %s MODIFY COLUMN %s", parent.getName(),
+				getDefinition(name, type, isNullable, autoIncrement, defaultExpression)));
+
+		this.nullable = isNullable;
+	}
+
+	@Override
+	public String getDefaultExpression() {
+		return defaultExpression;
+	}
+
+	@Override
+	public void setDefaultExpression(String newExpression) throws SQLException {
+		if (Strings.isNullOrEmpty(newExpression)) {
+			newExpression = null;
+		}
+
+		execute(String.format("ALTER TABLE %s MODIFY COLUMN %s", parent.getName(),
+				getDefinition(name, type, nullable, autoIncrement, newExpression)));
+
+		this.defaultExpression = newExpression;
+	}
+
+	@Override
+	public boolean isIdentity() {
+		return identity;
+	}
+
+	@Override
+	public void setIdentity(boolean identity) throws SQLException {
+		List<String> identityColumns = getParent().listColumns().stream()
+				.filter(c -> c.isIdentity())
+				.map(c -> c.getName())
+				.collect(Collectors.toList());
+
+		if (identity) {
+			identityColumns.add(name);
+		}
+
+		execute(String.format("ALTER TABLE %s DROP PRIMARY KEY, ADD PRIMARY KEY(%s);", getParent().getName(),
+				Joiner.on(',').join(identityColumns)));
+
+		this.identity = identity;
+	}
+
+	@Override
+	public boolean isAutoIncrement() {
+		return autoIncrement;
+	}
+
+	@Override
+	public void drop() throws SQLException {
+		execute(String.format("ALTER TABLE %s DROP COLUMN %s", parent.getName(), name));
+	}
+
+	private void execute(String query) throws SQLException {
+		getParent().getParent().execute(query);
+	}
+
+	private String getDefinition(String name, String type, boolean nullable, boolean autoIncrement,
+			String defaultExpression) {
+
+		QueryBuilder queryBuilder = new QueryBuilder();
+
+		queryBuilder.append(name + " " + type);
+
+		if (!nullable) {
+			queryBuilder.append(" NOT NULL");
+		}
+
+		if (autoIncrement) {
+			queryBuilder.append(" AUTO_INCREMENT");
+		}
+		else if (!Strings.isNullOrEmpty(defaultExpression)) {
+			if (!defaultExpression.endsWith(")") && !defaultExpression.endsWith("'")) {
+				defaultExpression = "'" + defaultExpression + "'";
+			}
+
+			queryBuilder.append(" DEFAULT " + defaultExpression);
+		}
+
+		return queryBuilder.toString();
+	}
+
+}

--- a/src/main/java/io/quantumdb/nemesis/structure/mysql55/MysqlConstraint.java
+++ b/src/main/java/io/quantumdb/nemesis/structure/mysql55/MysqlConstraint.java
@@ -1,4 +1,4 @@
-package io.quantumdb.nemesis.structure.mysql;
+package io.quantumdb.nemesis.structure.mysql55;
 
 import java.sql.SQLException;
 

--- a/src/main/java/io/quantumdb/nemesis/structure/mysql55/MysqlDatabase.java
+++ b/src/main/java/io/quantumdb/nemesis/structure/mysql55/MysqlDatabase.java
@@ -1,0 +1,180 @@
+package io.quantumdb.nemesis.structure.mysql55;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Savepoint;
+import java.sql.Statement;
+import java.util.List;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import io.quantumdb.nemesis.structure.ColumnDefinition;
+import io.quantumdb.nemesis.structure.Database;
+import io.quantumdb.nemesis.structure.DatabaseCredentials;
+import io.quantumdb.nemesis.structure.QueryBuilder;
+import io.quantumdb.nemesis.structure.Sequence;
+import io.quantumdb.nemesis.structure.Table;
+import io.quantumdb.nemesis.structure.TableDefinition;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ToString
+@EqualsAndHashCode
+public class MysqlDatabase implements Database {
+
+	private Connection connection;
+
+	public void connect(DatabaseCredentials credentials) throws SQLException {
+		try {
+			Class.forName("com.mysql.jdbc.Driver");
+			this.connection = DriverManager.getConnection(credentials.getUrl(),
+					credentials.getUsername(), credentials.getPassword());
+		}
+		catch (ClassNotFoundException e) {
+			throw new SQLException(e);
+		}
+	}
+
+	@Override
+	public void close() throws SQLException {
+		connection.close();
+	}
+
+	@Override
+	public boolean supports(Feature feature) {
+		switch (feature) {
+			case COLUMN_CONSTRAINTS:
+			case DEFAULT_VALUE_FOR_TEXT:
+			case MULTIPLE_AUTO_INCREMENT_COLUMNS:
+			case RENAME_INDEX:
+				return false;
+			default:
+				return true;
+		}
+	}
+
+	@Override
+	public List<Table> listTables() throws SQLException {
+		String query = "SHOW TABLES";
+		List<Table> tables = Lists.newArrayList();
+		try (PreparedStatement statement = connection.prepareStatement(query)) {
+			log.debug(query);
+
+			ResultSet resultSet = statement.executeQuery();
+			while (resultSet.next()) {
+				String tableName = resultSet.getString(1);
+				tables.add(new MysqlTable(connection, this, tableName));
+			}
+		}
+
+		return tables;
+	}
+
+	@Override
+	public void atomicTableRename(String replacingTableName, String currentTableName, String archivedTableName)
+			throws SQLException {
+
+		Savepoint save = null;
+		boolean autoCommit = false;
+		try {
+			autoCommit = connection.getAutoCommit();
+			connection.setAutoCommit(false);
+			save = connection.setSavepoint();
+
+			String query = "RENAME TABLE %s TO %s, %s TO %s";
+			String formatted = String.format(query, currentTableName, archivedTableName, replacingTableName, currentTableName);
+			connection.createStatement().execute(formatted);
+
+			connection.commit();
+		}
+		catch (SQLException e) {
+			connection.rollback(save);
+			connection.setAutoCommit(autoCommit);
+		}
+	}
+
+	@Override
+	public List<Sequence> listSequences() throws SQLException {
+		// MySQL doesn't support sequences...?!?
+		return Lists.newArrayList();
+	}
+
+	@Override
+	public void dropContents() throws SQLException {
+		while (!listTables().isEmpty()) {
+			for (Table table : listTables()) {
+				try {
+					table.drop();
+				}
+				catch (SQLException e) {
+					log.warn(e.getMessage(), e);
+				}
+			}
+		}
+		for (Sequence sequence : listSequences()) {
+			sequence.drop();
+		}
+	}
+
+	@Override
+	public Table createTable(TableDefinition table) throws SQLException {
+		QueryBuilder queryBuilder = new QueryBuilder();
+		queryBuilder.append("CREATE TABLE " + table.getName() + " (");
+
+		boolean columnAdded = false;
+		for (ColumnDefinition column : table.getColumns()) {
+			if (columnAdded) {
+				queryBuilder.append(", ");
+			}
+
+			queryBuilder.append(column.getName() + " " + column.getType());
+			if (column.isIdentity()) {
+				queryBuilder.append(" PRIMARY KEY");
+			}
+			if (!column.isNullable()) {
+				queryBuilder.append(" NOT NULL");
+			}
+
+			if (column.isAutoIncrement()) {
+				queryBuilder.append(" AUTO_INCREMENT");
+			}
+			else if (!Strings.isNullOrEmpty(column.getDefaultExpression())) {
+				queryBuilder.append(" DEFAULT " + column.getDefaultExpression());
+			}
+
+			columnAdded = true;
+		}
+
+		queryBuilder.append(")");
+		execute(queryBuilder.toString());
+
+		return new MysqlTable(connection, this, table.getName());
+	}
+
+	void execute(String query) throws SQLException {
+		query(query);
+		log.debug(query);
+	}
+
+	@Override
+	public void query(String query) throws SQLException {
+		try (Statement statement = connection.createStatement()) {
+			statement.execute(query);
+		}
+		catch (SQLException e) {
+			log.error(e.getMessage() + " - " + query, e);
+			throw e;
+		}
+	}
+
+	@Override
+	public Connection getConnection() {
+		return connection;
+	}
+
+}

--- a/src/main/java/io/quantumdb/nemesis/structure/mysql55/MysqlForeignKey.java
+++ b/src/main/java/io/quantumdb/nemesis/structure/mysql55/MysqlForeignKey.java
@@ -1,4 +1,4 @@
-package io.quantumdb.nemesis.structure.mysql;
+package io.quantumdb.nemesis.structure.mysql55;
 
 import java.sql.SQLException;
 

--- a/src/main/java/io/quantumdb/nemesis/structure/mysql55/MysqlIndex.java
+++ b/src/main/java/io/quantumdb/nemesis/structure/mysql55/MysqlIndex.java
@@ -1,4 +1,4 @@
-package io.quantumdb.nemesis.structure.mysql;
+package io.quantumdb.nemesis.structure.mysql55;
 
 import java.sql.SQLException;
 

--- a/src/main/java/io/quantumdb/nemesis/structure/mysql55/MysqlSequence.java
+++ b/src/main/java/io/quantumdb/nemesis/structure/mysql55/MysqlSequence.java
@@ -1,4 +1,4 @@
-package io.quantumdb.nemesis.structure.mysql;
+package io.quantumdb.nemesis.structure.mysql55;
 
 import java.sql.SQLException;
 

--- a/src/main/java/io/quantumdb/nemesis/structure/mysql55/MysqlTable.java
+++ b/src/main/java/io/quantumdb/nemesis/structure/mysql55/MysqlTable.java
@@ -1,0 +1,216 @@
+package io.quantumdb.nemesis.structure.mysql55;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import io.quantumdb.nemesis.structure.Column;
+import io.quantumdb.nemesis.structure.ColumnDefinition;
+import io.quantumdb.nemesis.structure.Constraint;
+import io.quantumdb.nemesis.structure.ForeignKey;
+import io.quantumdb.nemesis.structure.Index;
+import io.quantumdb.nemesis.structure.QueryBuilder;
+import io.quantumdb.nemesis.structure.Table;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ToString
+@EqualsAndHashCode
+class MysqlTable implements Table {
+
+	private final Connection connection;
+	private final MysqlDatabase parent;
+	private final String name;
+
+	MysqlTable(Connection connection, MysqlDatabase parent, String name) {
+		this.connection = connection;
+		this.parent = parent;
+		this.name = name;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public void rename(String newName) throws SQLException {
+		execute(String.format("ALTER TABLE %s RENAME TO %s", name, newName));
+	}
+
+	@Override
+	public MysqlDatabase getParent() {
+		return parent;
+	}
+
+	@Override
+	public List<Column> listColumns() throws SQLException {
+		String query = "SHOW COLUMNS FROM " + name;
+
+		List<Column> columns = Lists.newArrayList();
+		try (Statement statement = connection.createStatement()) {
+			log.debug(query);
+			ResultSet resultSet = statement.executeQuery(query);
+
+			while (resultSet.next()) {
+				String columnName = resultSet.getString("Field");
+				String expression = resultSet.getString("Default");
+				boolean nullable = "YES".equalsIgnoreCase(resultSet.getString("Null"));
+				String type = resultSet.getString("Type");
+				boolean identity = resultSet.getString("Key").equals("PRI");
+				boolean autoIncrement = resultSet.getString("Extra").contains("auto_increment");
+
+				columns.add(new MysqlColumn(connection, this, columnName, expression, nullable, type,
+						identity, autoIncrement));
+			}
+		}
+
+		return columns;
+	}
+
+	@Override
+	public Column addColumn(ColumnDefinition column) throws SQLException {
+		if (column.isAutoIncrement() && listColumns().stream().filter(Column::isIdentity).count() > 0) {
+			throw new UnsupportedOperationException("Mysql 5.5 does not support auto increment on non primary key.");
+		}
+
+		QueryBuilder queryBuilder = new QueryBuilder();
+		queryBuilder.append("ALTER TABLE " + name);
+		queryBuilder.append(" ADD " + column.getName() + " " + column.getType());
+
+		if (!column.isNullable()) {
+			queryBuilder.append(" NOT NULL");
+		}
+
+		if (column.isAutoIncrement()) {
+			queryBuilder.append(" AUTO_INCREMENT");
+		}
+		else if (!Strings.isNullOrEmpty(column.getDefaultExpression())) {
+			queryBuilder.append(" DEFAULT " + column.getDefaultExpression());
+		}
+
+		execute(queryBuilder.toString());
+
+		MysqlColumn created = new MysqlColumn(connection, this, column);
+		if (column.isIdentity()) {
+			created.setIdentity(true);
+		}
+
+		return created;
+	}
+
+	@Override
+	public List<Index> listIndices() throws SQLException {
+		String query = "SHOW INDEXES FROM " + name;
+
+		List<Index> indices = Lists.newArrayList();
+		try (Statement statement = connection.createStatement()) {
+
+			log.debug(query);
+			ResultSet resultSet = statement.executeQuery(query);
+
+			while (resultSet.next()) {
+				String indexName = resultSet.getString("Key_name");
+				boolean isUnique = !resultSet.getBoolean("Non_unique");
+				boolean isPrimary = indexName.equals("PRIMARY");
+				indices.add(new MysqlIndex(this, indexName, isUnique, isPrimary));
+			}
+		}
+
+		return indices;
+	}
+
+	@Override
+	public Index createIndex(String name, boolean unique, String... columnNames) throws SQLException {
+		String columns = Joiner.on(',').join(columnNames);
+		if (unique) {
+			execute(String.format("CREATE UNIQUE INDEX %s ON %s (%s)", name, this.name, columns));
+		}
+		else {
+			execute(String.format("CREATE INDEX %s ON %s (%s)", name, this.name, columns));
+		}
+		return new MysqlIndex(this, name, unique, false);
+	}
+
+	@Override
+	public List<Constraint> listConstraints() throws SQLException {
+		String query = new QueryBuilder()
+				.append("SELECT column_name, constraint_name ")
+				.append("FROM information_schema.key_column_usage ")
+				.append("WHERE table_name = ?")
+				.toString();
+
+		List<Constraint> constraints = Lists.newArrayList();
+		try (PreparedStatement statement = connection.prepareStatement(query)) {
+			statement.setString(1, name);
+			ResultSet resultSet = statement.executeQuery();
+
+			while (resultSet.next()) {
+				String constraintName = resultSet.getString("constraint_name");
+				String columnName = resultSet.getString("column_name");
+				String constraintType = "CHECK";
+
+				if (constraintName.equals("PRIMARY")) {
+					constraintType = "PRIMARY";
+				}
+
+				constraints.add(new MysqlConstraint(this, constraintName, constraintType, columnName));
+			}
+		}
+		return constraints;
+	}
+
+	@Override
+	public Constraint createConstraint(String name, String type, String expression) throws SQLException {
+		throw new UnsupportedOperationException("MySQL does not support constraints? WTF!");
+	}
+
+	@Override
+	public List<ForeignKey> listForeignKeys() throws SQLException {
+		String query = new QueryBuilder()
+				.append("SELECT * ")
+				.append("FROM information_schema.key_column_usage ")
+				.append("WHERE table_schema = SCHEMA() AND table_name = ? AND referenced_table_name IS NOT NULL")
+				.toString();
+
+		List<ForeignKey> foreignKeys = Lists.newArrayList();
+		try (PreparedStatement statement = connection.prepareStatement(query)) {
+			statement.setString(1, name);
+			ResultSet resultSet = statement.executeQuery();
+
+			while (resultSet.next()) {
+				String constraintName = resultSet.getString("constraint_name");
+				foreignKeys.add(new MysqlForeignKey(this, constraintName));
+			}
+		}
+		return foreignKeys;
+	}
+
+	@Override
+	public ForeignKey addForeignKey(String constraint, String[] columns, String referencedTable, String[] referencedColumns)
+			throws SQLException {
+
+		execute(String.format("ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s)", name, constraint,
+				Joiner.on(',').join(columns), referencedTable, Joiner.on(',').join(referencedColumns)));
+
+		return new MysqlForeignKey(this, constraint);
+	}
+
+	@Override
+	public void drop() throws SQLException {
+		execute(String.format("DROP TABLE %s", this.name));
+	}
+
+	private void execute(String query) throws SQLException {
+		getParent().execute(query);
+	}
+
+}

--- a/src/main/java/io/quantumdb/nemesis/structure/mysql56/MysqlConstraint.java
+++ b/src/main/java/io/quantumdb/nemesis/structure/mysql56/MysqlConstraint.java
@@ -1,0 +1,51 @@
+package io.quantumdb.nemesis.structure.mysql56;
+
+import java.sql.SQLException;
+
+import io.quantumdb.nemesis.structure.Constraint;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ToString
+@EqualsAndHashCode
+class MysqlConstraint implements Constraint {
+
+	private final MysqlTable parent;
+	private final String name;
+	private final String type;
+	private final String expression;
+
+	MysqlConstraint(MysqlTable parent, String name, String type, String expression) {
+		this.parent = parent;
+		this.name = name;
+		this.type = type;
+		this.expression = expression;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public MysqlTable getParent() {
+		return parent;
+	}
+
+	@Override
+	public String getType() {
+		return type;
+	}
+
+	@Override
+	public void drop() throws SQLException {
+		execute(String.format("ALTER ONLINE TABLE %s DROP CONSTRAINT %s", parent.getName(), name));
+	}
+
+	private void execute(String query) throws SQLException {
+		getParent().getParent().execute(query);
+	}
+
+}

--- a/src/main/java/io/quantumdb/nemesis/structure/mysql56/MysqlDatabase.java
+++ b/src/main/java/io/quantumdb/nemesis/structure/mysql56/MysqlDatabase.java
@@ -1,4 +1,4 @@
-package io.quantumdb.nemesis.structure.mysql;
+package io.quantumdb.nemesis.structure.mysql56;
 
 import java.sql.Connection;
 import java.sql.DriverManager;

--- a/src/main/java/io/quantumdb/nemesis/structure/mysql56/MysqlForeignKey.java
+++ b/src/main/java/io/quantumdb/nemesis/structure/mysql56/MysqlForeignKey.java
@@ -1,0 +1,31 @@
+package io.quantumdb.nemesis.structure.mysql56;
+
+import java.sql.SQLException;
+
+import io.quantumdb.nemesis.structure.ForeignKey;
+
+class MysqlForeignKey implements ForeignKey {
+
+	private final MysqlTable parent;
+	private final String name;
+
+	MysqlForeignKey(MysqlTable parent, String name) {
+		this.parent = parent;
+		this.name = name;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public void drop() throws SQLException {
+		execute(String.format("ALTER TABLE %s DROP FOREIGN KEY %s, ALGORITHM=INPLACE, LOCK=NONE", parent.getName(), name));
+	}
+
+	private void execute(String query) throws SQLException {
+		parent.getParent().execute(query);
+	}
+
+}

--- a/src/main/java/io/quantumdb/nemesis/structure/mysql56/MysqlIndex.java
+++ b/src/main/java/io/quantumdb/nemesis/structure/mysql56/MysqlIndex.java
@@ -1,0 +1,62 @@
+package io.quantumdb.nemesis.structure.mysql56;
+
+import java.sql.SQLException;
+
+import io.quantumdb.nemesis.structure.Index;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ToString
+@EqualsAndHashCode
+class MysqlIndex implements Index {
+
+	private final MysqlTable parent;
+	private final String name;
+
+	private final boolean unique;
+	private final boolean primary;
+
+	MysqlIndex(MysqlTable parent, String name, boolean unique, boolean primary) {
+		this.parent = parent;
+		this.name = name;
+		this.unique = unique;
+		this.primary = primary;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public MysqlTable getParent() {
+		return parent;
+	}
+
+	@Override
+	public boolean isUnique() {
+		return unique;
+	}
+
+	@Override
+	public boolean isPrimary() {
+		return primary;
+	}
+
+	@Override
+	public void rename(String name) throws SQLException {
+		throw new UnsupportedOperationException("Mysql 5.5 does not support renaming indices.");
+	}
+
+	@Override
+	public void drop() throws SQLException {
+		execute(String.format("ALTER TABLE %s DROP INDEX %s, ALGORITHM=INPLACE", parent.getName(), name));
+	}
+
+	private void execute(String query) throws SQLException {
+		getParent().getParent().execute(query);
+	}
+
+}

--- a/src/main/java/io/quantumdb/nemesis/structure/mysql56/MysqlSequence.java
+++ b/src/main/java/io/quantumdb/nemesis/structure/mysql56/MysqlSequence.java
@@ -1,0 +1,42 @@
+package io.quantumdb.nemesis.structure.mysql56;
+
+import java.sql.SQLException;
+
+import io.quantumdb.nemesis.structure.Sequence;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ToString
+@EqualsAndHashCode
+class MysqlSequence implements Sequence {
+
+	private final MysqlDatabase parent;
+	private final String name;
+
+	MysqlSequence(MysqlDatabase parent, String name) {
+		this.parent = parent;
+		this.name = name;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public MysqlDatabase getParent() {
+		return parent;
+	}
+
+	@Override
+	public void drop() throws SQLException {
+		execute(String.format("DROP SEQUENCE %s", name));
+	}
+
+	private void execute(String query) throws SQLException {
+		getParent().execute(query);
+	}
+
+}

--- a/src/test/java/io/quantumdb/nemesis/backends/BackendTest.java
+++ b/src/test/java/io/quantumdb/nemesis/backends/BackendTest.java
@@ -10,6 +10,7 @@ import io.quantumdb.nemesis.profiler.DatabaseStructure;
 import io.quantumdb.nemesis.profiler.Profiler;
 import io.quantumdb.nemesis.profiler.ProfilerConfig;
 import io.quantumdb.nemesis.structure.Database;
+import io.quantumdb.nemesis.structure.Database.Type;
 import io.quantumdb.nemesis.structure.DatabaseCredentials;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
@@ -23,9 +24,11 @@ public class BackendTest {
 	@Parameterized.Parameters(name = "{index}: type={0}")
 	public static Collection<?> getBackends() {
 		return Arrays.asList(new Object[][] {
-				{ Database.Type.POSTGRESQL, new DatabaseCredentials("jdbc:postgresql://localhost/profiler",
+				{ Type.POSTGRESQL, new DatabaseCredentials("jdbc:postgresql://localhost/profiler",
 						get("PG_USER", "profiler"), get("PG_PASSWORD", "profiler"))},
-				{ Database.Type.MYSQL, new DatabaseCredentials("jdbc:mysql://localhost/nemesis",
+				{ Type.MYSQL_55, new DatabaseCredentials("jdbc:mysql://localhost/nemesis",
+						get("MYSQL_USER", "root"), get("MYSQL_PASSWORD", "root")) },
+				{ Type.MYSQL_56, new DatabaseCredentials("jdbc:mysql://localhost/nemesis",
 						get("MYSQL_USER", "root"), get("MYSQL_PASSWORD", "root")) }
 		});
 	}

--- a/src/test/java/io/quantumdb/nemesis/backends/StructuralTest.java
+++ b/src/test/java/io/quantumdb/nemesis/backends/StructuralTest.java
@@ -7,6 +7,8 @@ import java.util.List;
 import com.google.common.base.Strings;
 import io.quantumdb.nemesis.structure.ColumnDefinition;
 import io.quantumdb.nemesis.structure.Database;
+import io.quantumdb.nemesis.structure.Database.Feature;
+import io.quantumdb.nemesis.structure.Database.Type;
 import io.quantumdb.nemesis.structure.DatabaseCredentials;
 import io.quantumdb.nemesis.structure.Table;
 import io.quantumdb.nemesis.structure.TableDefinition;
@@ -28,9 +30,11 @@ public class StructuralTest {
 	@Parameterized.Parameters(name = "{index} - {0}")
 	public static List<Object[]> listParameters() {
 		return Arrays.asList(new Object[][] {
-				{ Database.Type.POSTGRESQL, new DatabaseCredentials("jdbc:postgresql://localhost/profiler",
+				{ Type.POSTGRESQL, new DatabaseCredentials("jdbc:postgresql://localhost/profiler",
 						get("PG_USER", "profiler"), get("PG_PASSWORD", "profiler")) },
-				{ Database.Type.MYSQL, new DatabaseCredentials("jdbc:mysql://localhost/nemesis",
+				{ Type.MYSQL_55, new DatabaseCredentials("jdbc:mysql://localhost/nemesis",
+						get("MYSQL_USER", "root"), get("MYSQL_PASSWORD", "root")) },
+				{ Type.MYSQL_56, new DatabaseCredentials("jdbc:mysql://localhost/nemesis",
 						get("MYSQL_USER", "root"), get("MYSQL_PASSWORD", "root")) }
 		});
 	}
@@ -211,6 +215,8 @@ public class StructuralTest {
 
 	@Test
 	public void testMakingColumnAnIdentityColumn() throws SQLException {
+		Assume.assumeTrue(database.supports(Feature.MULTIPLE_AUTO_INCREMENT_COLUMNS));
+
 		testTableCreation();
 		database.getTable(TABLE_NAME)
 				.getColumn("name")


### PR DESCRIPTION
This PR adds support for MySQL 5.6. When using the 5.6 implementation, the DDL queries are also given a `ALGORITHM` and/or `LOCK` value to use, improving the behaviour of DDL queries in live production environments.
